### PR TITLE
Keyboard level ADC config options

### DIFF
--- a/hardware/at32f405xx/board_def.h
+++ b/hardware/at32f405xx/board_def.h
@@ -42,12 +42,15 @@
 // Number of ADC channels
 #define ADC_NUM_CHANNELS 16
 
-// ADC resolution in bits
-#define ADC_RESOLUTION 12
 // Maximum ADC value
 #define ADC_MAX_VALUE ((1 << ADC_RESOLUTION) - 1)
 
 #if !defined(ADC_NUM_SAMPLE_CYCLES)
 // Number of sample cycles for each ADC conversion
 #define ADC_NUM_SAMPLE_CYCLES ADC_SAMPLETIME_7_5
+#endif
+
+// ADC resolution in bits, set by `scripts/make.py`
+#if ADC_RESOLUTION != 12
+#error "Unsupported ADC resolution"
 #endif

--- a/hardware/at32f405xx/info.json
+++ b/hardware/at32f405xx/info.json
@@ -9,7 +9,7 @@
     "mcu": "at32f402_405"
   },
   "metadata": {
-    "adc_bits": 12,
+    "max_adc_resolution": 12,
     "adc_input_pins": [
       "A0",
       "A1",

--- a/hardware/stm32f446xx/board_def.h
+++ b/hardware/stm32f446xx/board_def.h
@@ -42,12 +42,23 @@
 // Number of ADC channels
 #define ADC_NUM_CHANNELS 16
 
-// ADC resolution in bits
-#define ADC_RESOLUTION 12
 // Maximum ADC value
 #define ADC_MAX_VALUE ((1 << ADC_RESOLUTION) - 1)
 
 #if !defined(ADC_NUM_SAMPLE_CYCLES)
 // Number of sample cycles for each ADC conversion
 #define ADC_NUM_SAMPLE_CYCLES ADC_SAMPLETIME_3CYCLES
+#endif
+
+// ADC resolution in bits, set by `scripts/make.py`
+#if ADC_RESOLUTION == 12
+#define ADC_RESOLUTION_HAL ADC_RESOLUTION_12B
+#elif ADC_RESOLUTION == 10
+#define ADC_RESOLUTION_HAL ADC_RESOLUTION_10B
+#elif ADC_RESOLUTION == 8
+#define ADC_RESOLUTION_HAL ADC_RESOLUTION_8B
+#elif ADC_RESOLUTION == 6
+#define ADC_RESOLUTION_HAL ADC_RESOLUTION_6B
+#else
+#error "Unsupported ADC resolution"
 #endif

--- a/hardware/stm32f446xx/info.json
+++ b/hardware/stm32f446xx/info.json
@@ -9,7 +9,7 @@
     "mcu": "stm32f4"
   },
   "metadata": {
-    "adc_bits": 12,
+    "max_adc_resolution": 12,
     "adc_input_pins": [
       "A0",
       "A1",

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -50,6 +50,8 @@ build_flags.define("USB_VENDOR_ID", kb_json["usb"]["vid"])
 build_flags.define("USB_PRODUCT_ID", kb_json["usb"]["pid"])
 
 # Analog Configuration
+build_flags.define("ADC_RESOLUTION", utils.get_adc_resolution(kb_json, driver_json))
+
 if kb_json["analog"].get("invert_adc", False):
     build_flags.define("MATRIX_INVERT_ADC_VALUES")
 

--- a/scripts/metadata.py
+++ b/scripts/metadata.py
@@ -38,7 +38,7 @@ metadata = {
     "name": kb_json["name"],
     "vendorId": kb_json["usb"]["vid"],
     "productId": kb_json["usb"]["pid"],
-    "adcBits": driver_json["metadata"]["adc_bits"],
+    "adcResolution": utils.get_adc_resolution(kb_json, driver_json),
     "numProfiles": kb_json["keyboard"]["num_profiles"],
     "numLayers": kb_json["keyboard"]["num_layers"],
     "numKeys": kb_json["keyboard"]["num_keys"],
@@ -52,6 +52,7 @@ compressed = gzip.compress(uncompressed)
 
 print(f"Uncompressed metadata size: {len(uncompressed)} bytes")
 print(f"Compressed metadata size: {len(compressed)} bytes")
+print(json.dumps(metadata, indent=2))
 
 with open(os.path.join("include", "metadata.h"), "w") as f:
     f.write(METADATA_HEADER.format(utils.to_c_array(compressed)))

--- a/scripts/schema/driver.schema.json
+++ b/scripts/schema/driver.schema.json
@@ -37,9 +37,9 @@
       "type": "object",
       "description": "Additional metadata about the driver.",
       "properties": {
-        "adc_bits": {
+        "max_adc_resolution": {
           "type": "integer",
-          "description": "The number of bits for the ADC resolution."
+          "description": "Maximum ADC resolution supported by the MCU."
         },
         "adc_input_pins": {
           "type": "array",
@@ -47,7 +47,7 @@
           "items": { "type": "string" }
         }
       },
-      "required": ["adc_bits", "adc_input_pins"]
+      "required": ["max_adc_resolution", "adc_input_pins"]
     }
   }
 }

--- a/scripts/schema/keyboard.schema.json
+++ b/scripts/schema/keyboard.schema.json
@@ -76,6 +76,10 @@
       "type": "object",
       "description": "Analog configuration",
       "properties": {
+        "adc_resolution": {
+          "type": "integer",
+          "description": "ADC resolution for this keyboard. A higher value means higher accuracy but slower matrix scans. Default to the maximum resolution supported by the MCU if not provided."
+        },
         "invert_adc": {
           "type": "boolean",
           "description": "Set to true if the ADC value is inversely proportional to the travel distance of the keys"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -106,3 +106,14 @@ def to_adc_input_array(channels_or_pins: list[str | int], driver_json: dict):
             assert x < len(adc_input_pins)
             channels.append(x)
     return to_c_array(channels)
+
+
+def get_adc_resolution(kb_json: dict, driver_json: dict):
+    """
+    Get the ADC resolution, or default to the maximum resolution supported by the MCU
+    """
+    return (
+        kb_json["analog"]["adc_resolution"]
+        if "adc_resolution" in kb_json["analog"]
+        else driver_json["metadata"]["max_adc_resolution"]
+    )

--- a/src/hardware/stm32f446xx/analog.c
+++ b/src/hardware/stm32f446xx/analog.c
@@ -111,7 +111,7 @@ void analog_init(void) {
   // Initialize the ADC peripheral
   adc_handle.Instance = ADC1;
   adc_handle.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV4;
-  adc_handle.Init.Resolution = ADC_RESOLUTION_12B;
+  adc_handle.Init.Resolution = ADC_RESOLUTION_HAL;
   adc_handle.Init.ScanConvMode = ENABLE;
   adc_handle.Init.ContinuousConvMode = DISABLE;
   adc_handle.Init.DiscontinuousConvMode = DISABLE;


### PR DESCRIPTION
Ignore my previous commit with the same topic, I left an additional commit in that one.

In case of additional slower controllers or more features in the future, having the option to reduce the resolution for faster matrix scanning could be helpful. It is set up so that the resolution object overwrites the ADC_RESOLUTION define in the board_def.h.

Additionally, setting the ADC resolution in the board_def.h is not necessary anymore, as the max ADC resolution is taken from the adc_bits object in the info.json, if no resolution is defined for the keyboard.

One potential problem is this:
In stm32f446xx/analog.c, this line exists:
adc_handle.Init.Resolution = ADC_RESOLUTION_12B;

I couldn't find the equivalent for the AT32, so it will need to be adjusted as well, if it exists.