### PR TITLE
:sparkles: add definition for HSE_VALUE in clock configuration

### DIFF
--- a/scripts/make.py
+++ b/scripts/make.py
@@ -38,6 +38,7 @@ build_flags.define("CFG_TUSB_MCU", f"OPT_MCU_{driver_json['tinyusb']['mcu'].uppe
 
 # Clock Configuration
 build_flags.define("BOARD_HSE_VALUE", kb_json["hardware"]["hse_value"])
+build_flags.define("HSE_VALUE", kb_json["hardware"]["hse_value"])
 
 # USB Configuration
 if kb_json["usb"]["port"] == "fs":


### PR DESCRIPTION
This is a known bug in the STM32F4 HAL.
It does not affect the current firmware (as no `HAL_*Get*Clock` functions are used) but its good tidy up!
https://github.com/platformio/platform-ststm32/issues/290

Platformio does not copy and modify the HAL file locally.
In the HAL file, `.platformio/packages/framework-stm32cube/f4/Drivers/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_conf.h`, the HSE_VALUE is hardcoded to 25000000.
This then populates: HAL_RCC_GetSysClockFreq which eventually populates all other HAL get clock functions.

I stumbled on this while I was reusing code to dynamically setup a counter overflow based on the clock frequency.