### PR TITLE
Reserve wear-leveling flash regions via linker 

### DIFF
--- a/linker/at32f405xc.ld
+++ b/linker/at32f405xc.ld
@@ -29,10 +29,17 @@ _board_bootloader_flag = _estack;
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
 
+/* Wear leveling flash reservation (provided via --defsym) */
+ASSERT(DEFINED(WL_FLASH_REGION_START),
+       "WL_FLASH_REGION_START must be defined (set in scripts/make.py)");
+ASSERT(DEFINED(WL_RESERVED_FLASH_SIZE),
+       "WL_RESERVED_FLASH_SIZE must be defined (set in scripts/make.py)");
+
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 256K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = WL_FLASH_REGION_START
+FLASH_WL (r)    : ORIGIN = 0x08000000 + WL_FLASH_REGION_START, LENGTH = WL_RESERVED_FLASH_SIZE
 RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 102K - 4 /* Reserve 4 bytes for bootloader */
 }
 

--- a/linker/stm32f446retx.ld
+++ b/linker/stm32f446retx.ld
@@ -43,11 +43,19 @@ _board_bootloader_flag = _estack;
 _Min_Heap_Size = 0x200; /* required amount of heap */
 _Min_Stack_Size = 0x400; /* required amount of stack */
 
+/* Wear leveling flash reservation (provided via --defsym) */
+ASSERT(DEFINED(WL_FLASH_REGION_START),
+       "WL_FLASH_REGION_START must be defined (set in scripts/make.py)");
+ASSERT(DEFINED(WL_RESERVED_FLASH_SIZE),
+       "WL_RESERVED_FLASH_SIZE must be defined (set in scripts/make.py)");
+
 /* Memories definition */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 128K - 4 /* Reserve 4 bytes for bootloader */
-  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 512K
+  /* WL_* values are provided via --defsym by scripts/make.py */
+  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = WL_FLASH_REGION_START
+  FLASH_WL (r)     : ORIGIN = 0x8000000 + WL_FLASH_REGION_START,   LENGTH = WL_RESERVED_FLASH_SIZE
 }
 
 /* Sections */

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -117,3 +117,41 @@ def get_adc_resolution(kb_json: dict, driver_json: dict):
         if "adc_resolution" in kb_json["analog"]
         else driver_json["metadata"]["max_adc_resolution"]
     )
+
+
+FLASH_SECTOR_SIZES = {
+    # Sector layout for STM32F446RE: 4x16K, 1x64K, 3x128K
+    "stm32f446xx": [
+        16 * 1024,
+        16 * 1024,
+        16 * 1024,
+        16 * 1024,
+        64 * 1024,
+        128 * 1024,
+        128 * 1024,
+        128 * 1024,
+    ],
+    # AT32F405RC: 128 uniform 2K sectors (256K total)
+    "at32f405xx": [2048] * 128,
+}
+
+
+def get_flash_sector_sizes(driver: str) -> list[int]:
+    """
+    Get the flash sector sizes for the given driver.
+    """
+    if driver not in FLASH_SECTOR_SIZES:
+        raise ValueError(f"Unsupported driver: {driver}")
+    return FLASH_SECTOR_SIZES[driver]
+
+
+def round_up_to_flash_sectors(required_size: int, sector_sizes: list[int]) -> int:
+    """
+    Round up the required size to the minimum number of flash sectors (from the end).
+    """
+    total = 0
+    for size in reversed(sector_sizes):
+        total += size
+        if total >= required_size:
+            return total
+    return total


### PR DESCRIPTION
Currently the linker script exposes the whole flash. This is a bit dangerous as we know we are reserving some space for emulated eeprom.
Even though the firmware size is small compared to the emulated eeprom it is still best practice to mark this space as read only.

The python scripts have been updated to pass the correct address space to reserve based on the json parameters for emulated eeprom. The result is passed as a build flag variable that the linker script can now use.