### PR TITLE
Add per-profile default keymaps support

### DIFF
--- a/include/eeconfig.h
+++ b/include/eeconfig.h
@@ -133,8 +133,8 @@ extern const eeconfig_t *eeconfig;
   }
 #endif
 
-#if !defined(DEFAULT_KEYMAP)
-#error "DEFAULT_KEYMAP is not defined"
+#if !defined(DEFAULT_KEYMAPS)
+#error "DEFAULT_KEYMAPS is not defined"
 #endif
 
 #if !defined(DEFAULT_ACTUATION_POINT)

--- a/scripts/get_deps.py
+++ b/scripts/get_deps.py
@@ -35,3 +35,20 @@ kb_json = utils.get_kb_json(keyboard)
 with open(os.path.join("scripts", "schema", "keyboard.schema.json")) as f:
     kb_schema = json.load(f)
 jsonschema.validate(kb_json, schema=kb_schema)
+
+# Validate default keymaps
+default_keymaps = utils.resolve_default_keymaps(kb_json)
+if len(default_keymaps) != kb_json["keyboard"]["num_profiles"]:
+    raise ValueError(
+        f"Expected default keymaps to have {kb_json['keyboard']['num_profiles']} profiles"
+    )
+for keymap in default_keymaps:
+    if len(keymap) != kb_json["keyboard"]["num_layers"]:
+        raise ValueError(
+            f"Expected default keymaps to have {kb_json['keyboard']['num_layers']} layers"
+        )
+    for layer in keymap:
+        if len(layer) != kb_json["keyboard"]["num_keys"]:
+            raise ValueError(
+                f"Expected default keymaps to have {kb_json['keyboard']['num_keys']} keys"
+            )

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -135,8 +135,9 @@ build_flags.define("NUM_LAYERS", kb["num_layers"])
 build_flags.define("NUM_KEYS", kb["num_keys"])
 build_flags.define("NUM_ADVANCED_KEYS", kb["num_advanced_keys"])
 
-# Default Keymap
-build_flags.define("DEFAULT_KEYMAP", utils.to_c_array(kb_json["keymap"]))
+# Default Keymaps (per profile)
+default_keymaps = utils.resolve_default_keymaps(kb_json)
+build_flags.define("DEFAULT_KEYMAPS", utils.to_c_array(default_keymaps))
 
 # Actuation Configuration
 if "actuation" in kb_json:

--- a/scripts/metadata.py
+++ b/scripts/metadata.py
@@ -45,7 +45,7 @@ metadata = {
     "numKeys": kb_json["keyboard"]["num_keys"],
     "numAdvancedKeys": kb_json["keyboard"]["num_advanced_keys"],
     "layout": kb_json["layout"],
-    "defaultKeymap": kb_json["keymap"],
+    "defaultKeymaps": utils.resolve_default_keymaps(kb_json),
 }
 
 uncompressed = json.dumps(metadata).encode("utf-8")

--- a/scripts/schema/keyboard.schema.json
+++ b/scripts/schema/keyboard.schema.json
@@ -210,6 +210,17 @@
         "items": { "type": "string" }
       }
     },
+    "keymaps": {
+      "type": "array",
+      "description": "Default keymaps for each profile. If not specified, the default keymap will be used for all profiles.",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
     "actuation": {
       "type": "object",
       "description": "Actuation configuration",
@@ -232,7 +243,6 @@
     "hardware",
     "analog",
     "calibration",
-    "layout",
-    "keymap"
+    "layout"
   ]
 }

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -77,3 +77,16 @@ def to_c_struct(value: dict):
 # Get the ADC resolution, or default to the maximum resolution supported by the MCU
 def get_adc_resolution(kb_json: dict, driver: Driver):
     return kb_json["analog"].get("adc_resolution", driver.metadata.adc.max_resolution)
+
+
+# Resolve per-profile default keymaps
+def resolve_default_keymaps(kb_json: dict) -> list[list[list[str]]]:
+    if "keymaps" in kb_json:
+        return kb_json["keymaps"]
+    else:
+        # Fallback to default keymap
+        if "keymap" not in kb_json:
+            raise ValueError(
+                "Default keymap must be specified when no per-profile default keymaps are specified"
+            )
+        return [kb_json["keymap"]] * kb_json["keyboard"]["num_profiles"]

--- a/src/eeconfig.c
+++ b/src/eeconfig.c
@@ -23,11 +23,21 @@ const eeconfig_t *eeconfig;
 // Default configuration values
 static eeconfig_options_t default_options = DEFAULT_OPTIONS;
 static eeconfig_calibration_t default_calibration = DEFAULT_CALIBRATION;
+static const uint8_t
+    default_keymaps[NUM_PROFILES][NUM_LAYERS][NUM_KEYS] = DEFAULT_KEYMAPS;
 static eeconfig_profile_t default_profile = {
-    .keymap = DEFAULT_KEYMAP,
     .gamepad_options = DEFAULT_GAMEPAD_OPTIONS,
     .tick_rate = DEFAULT_TICK_RATE,
 };
+
+static bool eeconfig_write_default_profile(uint8_t profile) {
+  if (profile >= NUM_PROFILES)
+    return false;
+
+  memcpy(default_profile.keymap, default_keymaps[profile],
+         sizeof(default_profile.keymap));
+  return EECONFIG_WRITE(profiles[profile], &default_profile);
+}
 
 static bool eeconfig_is_latest_version(void) {
   return eeconfig->magic_start == EECONFIG_MAGIC_START &&
@@ -66,7 +76,7 @@ bool eeconfig_reset(void) {
   EECONFIG_WRITE_LOCAL(current_profile, 0);
   EECONFIG_WRITE_LOCAL(last_non_default_profile, M_MIN(1, NUM_PROFILES - 1));
   for (uint32_t i = 0; i < NUM_PROFILES; i++)
-    status &= EECONFIG_WRITE(profiles[i], &default_profile);
+    status &= eeconfig_write_default_profile(i);
   EECONFIG_WRITE_LOCAL(magic_end, EECONFIG_MAGIC_END);
 
   return status;
@@ -78,5 +88,5 @@ bool eeconfig_reset_profile(uint8_t profile) {
   if (profile >= NUM_PROFILES)
     return false;
 
-  return EECONFIG_WRITE(profiles[profile], &default_profile);
+  return eeconfig_write_default_profile(profile);
 }


### PR DESCRIPTION
Currently by default all profiles match the default keymap.
Added the optional profile_keymaps array to the schema.
This is an array of keymaps, one per profile. Any empty profiles default to the default keymap.