### PR TITLE
Adjust timer period for ADC sampling rate STM32F446

### DIFF
--- a/src/hardware/stm32f446xx/analog.c
+++ b/src/hardware/stm32f446xx/analog.c
@@ -194,7 +194,7 @@ void analog_init(void) {
   tim_handle.Instance = TIM10;
   tim_handle.Init.Prescaler = 0;
   tim_handle.Init.CounterMode = TIM_COUNTERMODE_UP;
-  tim_handle.Init.Period = (F_CPU / 2000000) * ADC_SAMPLE_DELAY - 1;
+  tim_handle.Init.Period = (F_CPU / 1000000) * ADC_SAMPLE_DELAY - 1;
   tim_handle.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
   tim_handle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
   if (HAL_TIM_Base_Init(&tim_handle) != HAL_OK)


### PR DESCRIPTION
The division was wrong by a factor of 2 which ment that resultant delay was half what is expected. I have traced the TIM10 clock source and indeed it wrong. I have also measured this with a scope.
The maths on at32f405 are correct as is the assertion for out of bounds time.