### PR TITLE
:recycle: Refactor command handling to use a queue mechanism for prossessing raw HID commands

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -207,10 +207,22 @@ _Static_assert(sizeof(command_out_buffer_t) <= RAW_HID_EP_SIZE,
 void command_init(void);
 
 /**
- * @brief Process a command buffer received from the raw HID interface
+ * @brief Queue a command buffer received from the raw HID interface
  *
- * @param in_buf Command buffer
+ * Note that only one command can be queued at a time. The queued command will
+ * be processed in the next call to `command_task`. Any subsequent commands
+ * while a command is queued will be dropped.
+ *
+ * @param buf Command buffer
+ * @param len Buffer length in bytes
+ *
+ * @return `true` if the command was queued
+ */
+bool command_enqueue(const uint8_t *buf, uint16_t len);
+
+/**
+ * @brief Process queued raw HID commands and send pending responses
  *
  * @return None
  */
-void command_process(const uint8_t *buf);
+void command_task(void);

--- a/src/commands.c
+++ b/src/commands.c
@@ -29,13 +29,39 @@
     break;                                                                     \
   }
 
-static uint8_t out_buf[RAW_HID_EP_SIZE];
 static const uint8_t keyboard_metadata[] = {KEYBOARD_METADATA};
 
-void command_init(void) {}
+// `volatile` to prevent compiler optimizations
+static volatile bool command_request_pending;
+static volatile bool command_response_pending;
+static uint8_t in_buf[RAW_HID_EP_SIZE];
+static uint8_t out_buf[RAW_HID_EP_SIZE];
 
-void command_process(const uint8_t *buf) {
-  const command_in_buffer_t *in = (const command_in_buffer_t *)buf;
+void command_init(void) {
+  command_request_pending = false;
+  command_response_pending = false;
+}
+
+bool command_enqueue(const uint8_t *buf, uint16_t len) {
+  if (len != RAW_HID_EP_SIZE || command_request_pending ||
+      command_response_pending)
+    // Either `command_request_pending` or `command_response_pending` is set
+    // means that there is already a command queued.
+    return false;
+
+  memcpy(in_buf, buf, RAW_HID_EP_SIZE);
+  command_request_pending = true;
+
+  return true;
+}
+
+/**
+ * @brief Process the queued command and write the response
+ *
+ * @return None
+ */
+static void command_process(void) {
+  const command_in_buffer_t *in = (const command_in_buffer_t *)in_buf;
   command_out_buffer_t *out = (command_out_buffer_t *)out_buf;
 
   bool success = true;
@@ -300,9 +326,17 @@ void command_process(const uint8_t *buf) {
 
   // Echo the command ID back to the host if successful
   out->command_id = success ? in->command_id : COMMAND_UNKNOWN;
+}
 
-  while (!tud_hid_n_ready(USB_ITF_RAW_HID))
-    // Wait for the raw HID interface to be ready
-    tud_task();
-  tud_hid_n_report(USB_ITF_RAW_HID, 0, out_buf, RAW_HID_EP_SIZE);
+void command_task(void) {
+  if (command_request_pending) {
+    command_process();
+    command_request_pending = false;
+    command_response_pending = true;
+  }
+
+  if (command_response_pending && tud_hid_n_ready(USB_ITF_RAW_HID) &&
+      tud_hid_n_report(USB_ITF_RAW_HID, 0, out_buf, RAW_HID_EP_SIZE))
+    // The command response has been sent, so clear the queue.
+    command_response_pending = false;
 }

--- a/src/hid.c
+++ b/src/hid.c
@@ -229,8 +229,9 @@ uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id,
 void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id,
                            hid_report_type_t report_type, const uint8_t *buffer,
                            uint16_t bufsize) {
-  if (instance == USB_ITF_RAW_HID)
-    command_process(buffer);
+  if (instance == USB_ITF_RAW_HID && report_id == 0 &&
+      report_type == HID_REPORT_TYPE_OUTPUT)
+    command_enqueue(buffer, bufsize);
 }
 
 void tud_hid_report_complete_cb(uint8_t instance, const uint8_t *report,

--- a/src/main.c
+++ b/src/main.c
@@ -52,6 +52,7 @@ int main(void) {
   while (1) {
     tud_task();
 
+    command_task();
     analog_task();
     matrix_scan();
     layout_task();


### PR DESCRIPTION
If a rawHID request takes too long to reply the keyboard is stuck in a tud_task() loop.
By creating a single entry mailbox (1 entry queue) we are not stuck in a loop and we serve the mailbox when its pending.